### PR TITLE
CSS tweaks, mostly to fix Safari

### DIFF
--- a/src/components/button/index.module.scss
+++ b/src/components/button/index.module.scss
@@ -12,7 +12,7 @@
   text-decoration: none;
   margin: 0;
   border: none;
-  font-weight: 500;
+  font-weight: 400;
   user-select: none;
   padding: 0 32px;
   position: relative;

--- a/src/components/loader/loader.module.scss
+++ b/src/components/loader/loader.module.scss
@@ -41,7 +41,7 @@
   padding-bottom: 24px;
   text-align: center;
   line-height: 1.5;
-  font-weight: 500;
+  font-weight: 400;
 
   @media (min-width: $non-mobile) {
     max-width: 350px;

--- a/src/components/nav/nav.module.scss
+++ b/src/components/nav/nav.module.scss
@@ -16,14 +16,14 @@
 .links {
   padding-top: 24px;
   display: block;
-  height: 70px;
+  min-height: 70px;
 }
 
 .link {
   display: inline-block;
   font-size: 14px;
   text-decoration: none;
-  font-weight: 800;
+  font-weight: 700;
   color: #fff;
   position: relative;
   border: none;

--- a/src/components/profile/profile.module.scss
+++ b/src/components/profile/profile.module.scss
@@ -72,7 +72,7 @@
 
 .name {
   margin: 0;
-  font-weight: 600;
+  font-weight: 700;
   grid-column: 2 / 5;
   grid-row: 1 / 2;
   align-self: center;

--- a/src/pages/about.module.scss
+++ b/src/pages/about.module.scss
@@ -39,13 +39,13 @@
 
 h1.pageTitle {
   font-size: 32px;
-  font-weight: 600;
+  font-weight: 700;
   margin-bottom: 32px;
   color: $primary-purple;
 }
 h2.subheading {
   font-size: 20px;
-  font-weight: 600;
+  font-weight: 700;
   margin-bottom: 18px;
   color: $primary-purple;
 }

--- a/src/pages/index.module.scss
+++ b/src/pages/index.module.scss
@@ -24,9 +24,7 @@
   overflow-y: scroll;
   background-color: var(--white);
   @media (min-width: $desktop) {
-    min-width: var(--sidebar);
-    width: var(--sidebar);
-    max-width: var(--sidebar);
+    min-width: $sidebar;
     height: 100vh;
     display: flex;
     flex-direction: column;
@@ -55,14 +53,14 @@
 
   @media (min-width: $non-mobile) {
     grid-template-columns: repeat(2, 1fr);
-    grid-gap: 2.5rem 2rem;
+    grid-gap: 1.5rem;
     @supports not (display: grid) {
       display: block;
     }
   }
   @media (min-width: $desktop) {
-    grid-template-columns: repeat(auto-fill, minmax(250px, 1fr));
-    grid-gap: 2.5rem 2rem;
+    grid-template-columns: repeat(auto-fill, minmax(14em, 1fr));
+    grid-gap: 1.5rem;
     @supports not (display: grid) {
       display: block;
     }
@@ -102,7 +100,7 @@
 }
 
 .pageNumberButton:disabled {
-  font-weight: 500;
+  font-weight: 400;
   --text: white;
   --background: var(--gray);
   background-color: $primary-purple;
@@ -163,7 +161,7 @@
   border-bottom: 1px solid var(--border-gray);
   h2 {
     text-align: center;
-    font-weight: 500;
+    font-weight: 400;
   }
 }
 
@@ -198,7 +196,7 @@
   margin-left: auto;
   font-size: 13px;
   font-family: "pitch sans web", monospace;
-  font-weight: 600;
+  font-weight: 400;
   text-transform: uppercase;
   padding: 0 6px;
   border: 0;

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -17,7 +17,6 @@
   --background: white;
   --text: var(--gray);
   --page-shell-padding: 24px;
-  --sidebar: 310px;
   --sidebar-height: 208px;
 
   color: var(--gray);

--- a/src/styles/index.scss
+++ b/src/styles/index.scss
@@ -125,9 +125,6 @@ nav,
 section {
   display: block;
 }
-body {
-  line-height: 1;
-}
 ol,
 ul {
   list-style: none;

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -1,4 +1,4 @@
-@import url("https://fonts.googleapis.com/css2?family=Karla&display=swap");
+@import url("https://fonts.googleapis.com/css2?family=Karla:wght@400;700&display=swap");
 
 $sidebar: 310px;
 $non-mobile: 535px;


### PR DESCRIPTION
- fix Karla to load bold weight, and reset font-weight rules everywhere to 400 or 700
- simplify sidebar width CSS
- decrease min size of columns for desktop grid
- decrease grid spacing

Among other things, this fixes this problem on Safari:

<img width="315" alt="image" src="https://user-images.githubusercontent.com/71433/78505323-c1b99a00-7740-11ea-8cb9-bae8873af18b.png">
